### PR TITLE
measurements in dataPointSequences.json renamed to data-streams.json,…

### DIFF
--- a/src/main/kotlin/dk/cachet/carp/webservices/summary/controller/SummaryController.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/summary/controller/SummaryController.kt
@@ -15,7 +15,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
-import java.util.*
 
 @RestController
 @RequestMapping(SUMMARY_BASE)
@@ -57,7 +56,7 @@ class SummaryController(
         val file = summaryService.downloadSummary(summaryId)
         return ResponseEntity.ok().header(
             HttpHeaders.CONTENT_DISPOSITION,
-            "attachment; filename=\"$summaryId.zip\""
+            "attachment; filename=\"${file.filename}\""
         ).body(file)
     }
 

--- a/src/main/kotlin/dk/cachet/carp/webservices/summary/repository/SummaryRepository.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/summary/repository/SummaryRepository.kt
@@ -2,14 +2,11 @@ package dk.cachet.carp.webservices.summary.repository
 
 import dk.cachet.carp.webservices.summary.domain.Summary
 import dk.cachet.carp.webservices.summary.domain.SummaryStatus
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
-import java.util.*
 
 @Repository
 interface SummaryRepository: JpaRepository<Summary, String>

--- a/src/main/kotlin/dk/cachet/carp/webservices/summary/service/impl/ResourceExporterServiceImpl.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/summary/service/impl/ResourceExporterServiceImpl.kt
@@ -177,7 +177,7 @@ class ResourceExporterServiceImpl
             summaryLog.infoLogs.add("No dataStreamSequences was found.")
             return
         }
-        val dataPointsPath = resolveFullPathForFilename("${rootFolder.fileName}/dataPointSequences.json")
+        val dataPointsPath = resolveFullPathForFilename("${rootFolder.fileName}/data-streams.json")
         createFileForResourceOnPath(dataPointsPath, dataStreamSequences, summaryLog)
     }
 


### PR DESCRIPTION
… when downloading summary, and change of naming <study_id>_<date_time_of_generation>.zip.

fixing these issues:
https://github.com/cph-cachet/carp-webservices-spring/issues/15