### PR TITLE
Revoke claims through authorizers when resources get deleted

### DIFF
--- a/src/main/kotlin/dk/cachet/carp/webservices/common/authorization/ApplicationServiceAuthorizer.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/common/authorization/ApplicationServiceAuthorizer.kt
@@ -13,12 +13,12 @@ interface ApplicationServiceAuthorizer<
 {
     fun TRequest.authorize()
 
-    suspend fun TRequest.grantClaimsOnSuccess( result: Any? )
+    suspend fun TRequest.changeClaimsOnSuccess(result: Any? )
 
     fun authorizeRequest( request: TRequest ) = request.authorize()
 
     suspend fun grantClaimsOnSuccessfulRequest( request: TRequest, result: Any? ) =
-        request.grantClaimsOnSuccess( result )
+        request.changeClaimsOnSuccess( result )
 }
 
 class ApplicationServiceRequestAuthorizer<

--- a/src/main/kotlin/dk/cachet/carp/webservices/data/authorization/DataStreamServiceAuthorizer.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/data/authorization/DataStreamServiceAuthorizer.kt
@@ -26,7 +26,7 @@ class DataStreamServiceAuthorizer(
                 auth.require( studyDeploymentIds.map { Claim.ManageDeployment( it ) }.toSet() )
         }
 
-    override suspend fun DataStreamServiceRequest<*>.grantClaimsOnSuccess( result: Any? ) =
+    override suspend fun DataStreamServiceRequest<*>.changeClaimsOnSuccess(result: Any? ) =
         when ( this ) {
             is DataStreamServiceRequest.OpenDataStreams,
             is DataStreamServiceRequest.AppendToDataStreams,

--- a/src/main/kotlin/dk/cachet/carp/webservices/deployment/authorization/DeploymentServiceAuthorizer.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/deployment/authorization/DeploymentServiceAuthorizer.kt
@@ -37,7 +37,7 @@ class DeploymentServiceAuthorizer(
                 auth.require( Claim.InDeployment( studyDeploymentId ) )
         }
 
-    override suspend fun DeploymentServiceRequest<*>.grantClaimsOnSuccess( result: Any? ) =
+    override suspend fun DeploymentServiceRequest<*>.changeClaimsOnSuccess(result: Any? ) =
         when ( this )
         {
             is DeploymentServiceRequest.CreateStudyDeployment -> {
@@ -50,7 +50,16 @@ class DeploymentServiceAuthorizer(
                     )
                 )
             }
-            is DeploymentServiceRequest.RemoveStudyDeployments,
+            is DeploymentServiceRequest.RemoveStudyDeployments -> {
+                studyDeploymentIds.forEach {
+                    auth.revokeClaimsFromAllAccounts(
+                        setOf(
+                            Claim.InDeployment( it ),
+                            Claim.ManageDeployment( it )
+                        )
+                    )
+                }
+            }
             is DeploymentServiceRequest.GetStudyDeploymentStatus,
             is DeploymentServiceRequest.GetStudyDeploymentStatusList,
             is DeploymentServiceRequest.RegisterDevice,

--- a/src/main/kotlin/dk/cachet/carp/webservices/deployment/authorization/ParticipationServiceAuthorizer.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/deployment/authorization/ParticipationServiceAuthorizer.kt
@@ -25,7 +25,7 @@ class ParticipationServiceAuthorizer(
         }
     }
 
-    override suspend fun ParticipationServiceRequest<*>.grantClaimsOnSuccess(result: Any?) {
+    override suspend fun ParticipationServiceRequest<*>.changeClaimsOnSuccess(result: Any?) {
         when ( this )
         {
             is ParticipationServiceRequest.GetActiveParticipationInvitations,

--- a/src/main/kotlin/dk/cachet/carp/webservices/protocol/authorization/ProtocolFactoryServiceAuthorizer.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/protocol/authorization/ProtocolFactoryServiceAuthorizer.kt
@@ -13,7 +13,7 @@ class ProtocolFactoryServiceAuthorizer : ApplicationServiceAuthorizer<ProtocolFa
         when ( this ) { is ProtocolFactoryServiceRequest.CreateCustomProtocol -> Unit }
     }
 
-    override suspend fun ProtocolFactoryServiceRequest<*>.grantClaimsOnSuccess( result: Any? )
+    override suspend fun ProtocolFactoryServiceRequest<*>.changeClaimsOnSuccess(result: Any? )
     {
         when ( this ) { is ProtocolFactoryServiceRequest.CreateCustomProtocol -> Unit }
     }

--- a/src/main/kotlin/dk/cachet/carp/webservices/protocol/authorization/ProtocolServiceAuthorizer.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/protocol/authorization/ProtocolServiceAuthorizer.kt
@@ -28,7 +28,7 @@ class ProtocolServiceAuthorizer(
             is ProtocolServiceRequest.GetVersionHistoryFor -> auth.require( Claim.ProtocolOwner( protocolId ) )
         }
 
-    override suspend fun ProtocolServiceRequest<*>.grantClaimsOnSuccess( result: Any? ) =
+    override suspend fun ProtocolServiceRequest<*>.changeClaimsOnSuccess(result: Any? ) =
         when ( this )
         {
             is ProtocolServiceRequest.Add ->

--- a/src/main/kotlin/dk/cachet/carp/webservices/security/authorization/service/AuthorizationService.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/security/authorization/service/AuthorizationService.kt
@@ -43,4 +43,14 @@ interface AuthorizationService
      * Grant the current authentication all specified [claims].
      */
     suspend fun grantCurrentAuthentication( claims: Set<Claim> )
+
+    /**
+     * Revoke the specified [claim] from every account that has it.
+     */
+    suspend fun revokeClaimFromAllAccounts( claim: Claim )
+
+    /**
+     * Revoke the specified [claims] from every account that has them.
+     */
+    suspend fun revokeClaimsFromAllAccounts( claims: Set<Claim> )
 }

--- a/src/main/kotlin/dk/cachet/carp/webservices/security/authorization/service/impl/AuthorizationServiceImpl.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/security/authorization/service/impl/AuthorizationServiceImpl.kt
@@ -49,11 +49,23 @@ class AuthorizationServiceImpl(
         require( authenticationService.getId() == ownerId, lazyMessage )
     }
 
-    override suspend fun grantCurrentAuthentication( claim: Claim ) = grantCurrentAuthentication( setOf( claim ) )
+    override suspend fun grantCurrentAuthentication( claim: Claim ) =
+        grantCurrentAuthentication( setOf( claim ) )
 
     override suspend fun grantCurrentAuthentication( claims: Set<Claim> )
     {
         accountService.grant( authenticationService.getCarpIdentity(), claims )
+    }
+
+    override suspend fun revokeClaimFromAllAccounts( claim: Claim ) = revokeClaimsFromAllAccounts( setOf( claim ) )
+
+    override suspend fun revokeClaimsFromAllAccounts( claims: Set<Claim> )
+    {
+        claims.forEach { claim ->
+            accountService.findAllByClaim( claim ).forEach {
+                accountService.revoke( it.getIdentity(), claims )
+            }
+        }
     }
 
     private fun isAdmin() = authenticationService.getRole() == Role.SYSTEM_ADMIN

--- a/src/main/kotlin/dk/cachet/carp/webservices/study/authorization/RecruitmentServiceAuthorizer.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/study/authorization/RecruitmentServiceAuthorizer.kt
@@ -24,7 +24,7 @@ class RecruitmentServiceAuthorizer(
             is RecruitmentServiceRequest.StopParticipantGroup -> auth.require( Claim.ManageStudy( studyId ) )
         }
 
-    override suspend fun RecruitmentServiceRequest<*>.grantClaimsOnSuccess( result: Any? ) =
+    override suspend fun RecruitmentServiceRequest<*>.changeClaimsOnSuccess(result: Any? ) =
         when ( this )
         {
             is RecruitmentServiceRequest.AddParticipantByEmailAddress,

--- a/src/main/kotlin/dk/cachet/carp/webservices/study/authorization/StudyServiceAuthorizer.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/study/authorization/StudyServiceAuthorizer.kt
@@ -34,7 +34,7 @@ class StudyServiceAuthorizer(
             is StudyServiceRequest.Remove -> auth.require( Claim.ManageStudy( studyId ) )
         }
 
-    override suspend fun StudyServiceRequest<*>.grantClaimsOnSuccess( result: Any? ) =
+    override suspend fun StudyServiceRequest<*>.changeClaimsOnSuccess(result: Any? ) =
         when ( this )
         {
             is StudyServiceRequest.CreateStudy -> {
@@ -48,7 +48,10 @@ class StudyServiceAuthorizer(
             is StudyServiceRequest.SetInvitation,
             is StudyServiceRequest.SetProtocol,
             is StudyServiceRequest.RemoveProtocol,
-            is StudyServiceRequest.GoLive,
-            is StudyServiceRequest.Remove -> Unit
+            is StudyServiceRequest.GoLive -> Unit
+            is StudyServiceRequest.Remove -> {
+                auth.revokeClaimFromAllAccounts( Claim.ManageStudy( studyId ) )
+            }
+
         }
 }


### PR DESCRIPTION
This solution will not revoke the claims if the resources get deleted through a call from the services event bus. However that shouldn't be a big issue, if one doesn't use the claims in a way that presumes the existence of the referenced objects.