### PR TITLE
Change export type and file name for exporting data

### DIFF
--- a/src/main/kotlin/dk/cachet/carp/webservices/export/command/ExportCommand.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/export/command/ExportCommand.kt
@@ -28,7 +28,7 @@ abstract class ExportCommand(
     open val entry: Export,
     open val logger: ExportLog = ExportLog(),
 ) {
-    abstract fun canExecute(): Boolean
+    abstract fun canExecute(): Pair<Boolean, String>
 
     abstract suspend fun execute()
 }
@@ -61,7 +61,7 @@ class ExportCommandFactory(
             if (deploymentIds.isNullOrEmpty()) {
                 ExportType.STUDY_DATA
             } else {
-                ExportType.PARTICIPANT_GROUP_DATA
+                ExportType.DEPLOYMENT_DATA
             }
 
         val entry =

--- a/src/main/kotlin/dk/cachet/carp/webservices/export/command/ExportCommandInvoker.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/export/command/ExportCommandInvoker.kt
@@ -17,7 +17,8 @@ class ExportCommandInvokerImpl(
     private val exportRepository: ExportRepository,
 ) : ExportCommandInvoker {
     override fun invoke(command: ExportCommand) {
-        require(command.canExecute()) { "Export cannot be started." }
+        val constrainCheck = command.canExecute()
+        require(constrainCheck.first) { constrainCheck.second }
 
         CoroutineScope(Dispatchers.IO + SecurityCoroutineContext()).launch {
             try {

--- a/src/main/kotlin/dk/cachet/carp/webservices/export/command/impl/ExportAnonymousParticipants.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/export/command/impl/ExportAnonymousParticipants.kt
@@ -35,15 +35,24 @@ class ExportAnonymousParticipants(
         const val CSV_HEADER = "username,study_deployment_id,access_link,expiry_date"
     }
 
-    override fun canExecute(): Boolean {
+    override fun canExecute(): Pair<Boolean, String> {
         val protocol =
             runBlocking(Dispatchers.IO + SecurityCoroutineContext()) {
                 services.studyService.getStudyDetails(studyId).protocolSnapshot
             }
 
-        return protocol != null &&
-            protocol.participantRoles.any { it.role == payload.participantRoleName } &&
-            payload.amountOfAccounts in 1..MAX_AMOUNT
+        val isLive =
+            runBlocking(Dispatchers.IO + SecurityCoroutineContext()) {
+                services.studyService.getStudyStatus(studyId).canDeployToParticipants
+            }
+
+        return when {
+            protocol == null -> Pair(false, "Study $studyId has not set protocol.")
+            !isLive -> Pair(false, "Study $studyId is not live.")
+            payload.amountOfAccounts !in 1..MAX_AMOUNT ->
+                Pair(false, "Amount of accounts must be between 1 and $MAX_AMOUNT.")
+            else -> Pair(true, "")
+        }
     }
 
     override suspend fun execute() {

--- a/src/main/kotlin/dk/cachet/carp/webservices/export/command/impl/ExportAnonymousParticipants.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/export/command/impl/ExportAnonymousParticipants.kt
@@ -47,10 +47,26 @@ class ExportAnonymousParticipants(
             }
 
         return when {
-            protocol == null -> Pair(false, "Study $studyId has not set protocol.")
-            !isLive -> Pair(false, "Study $studyId is not live.")
+            protocol == null ->
+                Pair(
+                    false,
+                    "Study $studyId does not have a protocol",
+                )
+            protocol.participantRoles.any { it.role != payload.participantRoleName } ->
+                Pair(
+                    false,
+                    "Participant role ${payload.participantRoleName} does not exist",
+                )
+            !isLive ->
+                Pair(
+                    false,
+                    "Study $studyId is not live",
+                )
             payload.amountOfAccounts !in 1..MAX_AMOUNT ->
-                Pair(false, "Amount of accounts must be between 1 and $MAX_AMOUNT.")
+                Pair(
+                    false,
+                    "Amount of accounts must be between 1 and $MAX_AMOUNT",
+                )
             else -> Pair(true, "")
         }
     }

--- a/src/main/kotlin/dk/cachet/carp/webservices/export/command/impl/ExportSummary.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/export/command/impl/ExportSummary.kt
@@ -21,7 +21,7 @@ class ExportSummary(
         private val LOGGER = LogManager.getLogger()
     }
 
-    override fun canExecute(): Boolean = true
+    override fun canExecute(): Pair<Boolean, String> = Pair(true, "")
 
     @OptIn(ExperimentalPathApi::class)
     override suspend fun execute() {

--- a/src/main/kotlin/dk/cachet/carp/webservices/export/domain/Export.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/export/domain/Export.kt
@@ -32,6 +32,6 @@ enum class ExportStatus {
 enum class ExportType {
     UNKNOWN,
     STUDY_DATA,
-    PARTICIPANT_GROUP_DATA,
+    DEPLOYMENT_DATA,
     ANONYMOUS_PARTICIPANTS,
 }

--- a/src/test/kotlin/dk/cachet/carp/webservices/export/command/ExportAnonymousParticipantsTest.kt
+++ b/src/test/kotlin/dk/cachet/carp/webservices/export/command/ExportAnonymousParticipantsTest.kt
@@ -57,7 +57,7 @@ class ExportAnonymousParticipantsTest {
                 )
             val canExecute = command.canExecute()
 
-            assertFalse(canExecute)
+            assertFalse(canExecute.first)
         }
 
         @Test
@@ -84,7 +84,7 @@ class ExportAnonymousParticipantsTest {
                 )
             val canExecute = command.canExecute()
 
-            assertFalse(canExecute)
+            assertFalse(canExecute.first)
         }
 
         @Test
@@ -116,7 +116,7 @@ class ExportAnonymousParticipantsTest {
                 )
             val canExecute = command.canExecute()
 
-            assertFalse(canExecute)
+            assertFalse(canExecute.first)
         }
     }
 }

--- a/src/test/kotlin/dk/cachet/carp/webservices/export/command/ExportAnonymousParticipantsTest.kt
+++ b/src/test/kotlin/dk/cachet/carp/webservices/export/command/ExportAnonymousParticipantsTest.kt
@@ -55,9 +55,9 @@ class ExportAnonymousParticipantsTest {
                     resourceExporter,
                     fileUtil,
                 )
-            val canExecute = command.canExecute()
+            val canExecute = command.canExecute().first
 
-            assertFalse(canExecute.first)
+            assertFalse(canExecute)
         }
 
         @Test
@@ -82,9 +82,9 @@ class ExportAnonymousParticipantsTest {
                     resourceExporter,
                     fileUtil,
                 )
-            val canExecute = command.canExecute()
+            val canExecute = command.canExecute().first
 
-            assertFalse(canExecute.first)
+            assertFalse(canExecute)
         }
 
         @Test
@@ -114,9 +114,9 @@ class ExportAnonymousParticipantsTest {
                     resourceExporter,
                     fileUtil,
                 )
-            val canExecute = command.canExecute()
+            val canExecute = command.canExecute().first
 
-            assertFalse(canExecute.first)
+            assertFalse(canExecute)
         }
     }
 }

--- a/src/test/kotlin/dk/cachet/carp/webservices/export/command/ExportCommandInvokerTest.kt
+++ b/src/test/kotlin/dk/cachet/carp/webservices/export/command/ExportCommandInvokerTest.kt
@@ -18,7 +18,7 @@ class ExportCommandInvokerTest {
         fun `should require command to be executable`() {
             val notExecutableCommand =
                 mockk<ExportCommand> {
-                    every { canExecute().first } returns false
+                    every { canExecute() } returns Pair(false, "Not executable")
                 }
 
             val sut = ExportCommandInvokerImpl(repository)
@@ -35,7 +35,7 @@ class ExportCommandInvokerTest {
 
                 val command =
                     mockk<ExportCommand> {
-                        every { canExecute().first } returns true
+                        every { canExecute() } returns Pair(true, "")
                         coEvery { execute() } answers { nothing }
                         every { entry } returns
                             mockk {

--- a/src/test/kotlin/dk/cachet/carp/webservices/export/command/ExportCommandInvokerTest.kt
+++ b/src/test/kotlin/dk/cachet/carp/webservices/export/command/ExportCommandInvokerTest.kt
@@ -18,7 +18,7 @@ class ExportCommandInvokerTest {
         fun `should require command to be executable`() {
             val notExecutableCommand =
                 mockk<ExportCommand> {
-                    every { canExecute() } returns false
+                    every { canExecute().first } returns false
                 }
 
             val sut = ExportCommandInvokerImpl(repository)
@@ -35,7 +35,7 @@ class ExportCommandInvokerTest {
 
                 val command =
                     mockk<ExportCommand> {
-                        every { canExecute() } returns true
+                        every { canExecute().first } returns true
                         coEvery { execute() } answers { nothing }
                         every { entry } returns
                             mockk {


### PR DESCRIPTION
Rename participant groups to deployments when exporting data
Add messages for errors when generating exports