### PR TITLE
Re-add Java Instant serializer

### DIFF
--- a/src/main/kotlin/dk/cachet/carp/webservices/common/serialisers/ObjectMapperConfig.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/common/serialisers/ObjectMapperConfig.kt
@@ -54,6 +54,8 @@ class ObjectMapperConfig(validationMessages: MessageBase) : SimpleModule() {
         this.addDeserializer(DataStreamBatch::class.java, DataStreamBatchDeserializer(validationMessages))
 
         this.addSerializer(Instant::class.java, KInstantSerializer.INSTANCE)
+
+        this.addSerializer(java.time.Instant::class.java, InstantSerializer.INSTANCE)
     }
 
     class KInstantSerializer : JsonSerializer<Instant>() {


### PR DESCRIPTION
Export entity is being used directly in controller, which is `Auditable` and use Java Instant,
we cannot change this yet, since Spring data JPA doesn't support Kotlinx.datatime,
consider write a Java.Instant - Kotlinx.Instant one-to-one converter in `Auditable`,
before that, Java.Instant should be used