### PR TITLE
Add ProtocolSnapshot Serializer

### DIFF
--- a/src/main/kotlin/dk/cachet/carp/webservices/account/serdes/StudyProtocolSnapshotSerializer.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/account/serdes/StudyProtocolSnapshotSerializer.kt
@@ -1,0 +1,56 @@
+package dk.cachet.carp.webservices.account.serdes
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
+import dk.cachet.carp.webservices.common.configuration.internationalisation.service.MessageBase
+import dk.cachet.carp.webservices.common.exception.serialization.SerializationException
+import dk.cachet.carp.webservices.common.input.WS_JSON
+import kotlinx.serialization.encodeToString
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+
+/**
+ * The Class [StudyProtocolSnapshotSerializer].
+ * The [StudyProtocolSnapshotSerializer] implements the serialization logic for [StudyProtocolSnapshot].
+ */
+@Suppress("TooGenericExceptionCaught", "SwallowedException")
+class StudyProtocolSnapshotSerializer(
+    private val validationMessages: MessageBase,
+) : JsonSerializer<StudyProtocolSnapshot>() {
+    companion object {
+        private val LOGGER: Logger = LogManager.getLogger()
+    }
+
+    /**
+     * The [serialize] function is used to serialize the parsed object.
+     *
+     * @param studyProtocolSnapshot The [studyProtocolSnapshot] object containing the json object parsed.
+     * @throws SerializationException If the [StudyProtocolSnapshot] is blank or empty.
+     * Also, if the [StudyProtocolSnapshot] contains invalid format.
+     * @return The serialization [StudyProtocolSnapshot] object.
+     */
+    override fun serialize(
+        studyProtocolSnapshot: StudyProtocolSnapshot?,
+        jsonGeneator: JsonGenerator?,
+        serializers: SerializerProvider?,
+    ) {
+        if (studyProtocolSnapshot == null) {
+            LOGGER.error("The core StudyProtocolSnapshot is null.")
+            throw SerializationException(validationMessages.get("protocol.snapshot.serialization.empty"))
+        }
+
+        val serialized: String
+        try {
+            serialized = WS_JSON.encodeToString(studyProtocolSnapshot)
+        } catch (ex: Exception) {
+            LOGGER.error("The core StudyProtocolSnapshot is not valid. Exception: ${ex.message}")
+            throw SerializationException(
+                validationMessages.get("protocol.snapshot.serialization.error", ex.message.toString()),
+            )
+        }
+
+        jsonGeneator!!.writeRawValue(serialized)
+    }
+}

--- a/src/main/kotlin/dk/cachet/carp/webservices/common/serialisers/ObjectMapperConfig.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/common/serialisers/ObjectMapperConfig.kt
@@ -13,8 +13,10 @@ import dk.cachet.carp.common.application.users.AccountIdentity
 import dk.cachet.carp.data.application.DataStreamBatch
 import dk.cachet.carp.data.application.Measurement
 import dk.cachet.carp.data.application.SyncPoint
+import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
 import dk.cachet.carp.webservices.account.serdes.AccountIdentityDeserializer
 import dk.cachet.carp.webservices.account.serdes.AccountIdentitySerializer
+import dk.cachet.carp.webservices.account.serdes.StudyProtocolSnapshotSerializer
 import dk.cachet.carp.webservices.common.configuration.internationalisation.service.MessageBase
 import dk.cachet.carp.webservices.common.serialisers.serdes.UUIDDeserializer
 import dk.cachet.carp.webservices.common.serialisers.serdes.UUIDSerializer
@@ -56,6 +58,8 @@ class ObjectMapperConfig(validationMessages: MessageBase) : SimpleModule() {
         this.addSerializer(Instant::class.java, KInstantSerializer.INSTANCE)
 
         this.addSerializer(java.time.Instant::class.java, InstantSerializer.INSTANCE)
+
+        this.addSerializer(StudyProtocolSnapshot::class.java, StudyProtocolSnapshotSerializer(validationMessages))
     }
 
     class KInstantSerializer : JsonSerializer<Instant>() {

--- a/src/main/kotlin/dk/cachet/carp/webservices/protocol/service/impl/ProtocolServiceWrapper.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/protocol/service/impl/ProtocolServiceWrapper.kt
@@ -12,7 +12,6 @@ import dk.cachet.carp.webservices.protocol.service.ProtocolService
 import dk.cachet.carp.webservices.security.authentication.domain.Account
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.json.Json
 import org.springframework.stereotype.Service
 
 @Service

--- a/src/test/kotlin/dk/cachet/carp/webservices/protocol/service/ProtocolServiceTest.kt
+++ b/src/test/kotlin/dk/cachet/carp/webservices/protocol/service/ProtocolServiceTest.kt
@@ -17,10 +17,12 @@ import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlinx.datetime.toJavaInstant
-import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
-import kotlin.test.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 


### PR DESCRIPTION
This is needed when Export study and deployments,
until we export using core snapshot, we need to configure ObjectMapper to build Json