### PR TITLE
Changed from throw to warn

### DIFF
--- a/src/main/kotlin/dk/cachet/carp/webservices/common/email/service/impl/EmailInvitationServiceImpl.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/common/email/service/impl/EmailInvitationServiceImpl.kt
@@ -2,7 +2,6 @@ package dk.cachet.carp.webservices.common.email.service.impl
 
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.deployments.application.users.StudyInvitation
-import dk.cachet.carp.webservices.common.configuration.internationalisation.service.MessageBase
 import dk.cachet.carp.webservices.common.email.domain.EmailRequest
 import dk.cachet.carp.webservices.common.email.domain.EmailType
 import dk.cachet.carp.webservices.common.email.listener.EmailSendingJob
@@ -10,7 +9,6 @@ import dk.cachet.carp.webservices.common.email.service.EmailInvitationService
 import dk.cachet.carp.webservices.common.email.service.impl.javamail.EmailServiceImpl
 import dk.cachet.carp.webservices.common.email.util.EmailTemplateUtil
 import dk.cachet.carp.webservices.common.email.util.EmailValidatorUtil
-import dk.cachet.carp.webservices.common.exception.responses.BadRequestException
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import org.springframework.stereotype.Service
@@ -27,7 +25,8 @@ class EmailInvitationServiceImpl(
     companion object {
         private val LOGGER: Logger = LogManager.getLogger()
     }
-        override fun inviteToStudy(
+
+    override fun inviteToStudy(
         email: String,
         deploymentId: UUID,
         invitation: StudyInvitation,
@@ -72,6 +71,6 @@ class EmailInvitationServiceImpl(
     }
 
     private fun isEmailAddressValid(emailAddress: String?): Boolean {
-        return this.emailValidator.isValid(emailAddress);
+        return this.emailValidator.isValid(emailAddress)
     }
 }

--- a/src/test/kotlin/dk/cachet/carp/webservices/common/email/service/impl/EmailInvitationServiceImplTest.kt
+++ b/src/test/kotlin/dk/cachet/carp/webservices/common/email/service/impl/EmailInvitationServiceImplTest.kt
@@ -1,0 +1,43 @@
+package dk.cachet.carp.webservices.common.email.service.impl
+
+import dk.cachet.carp.common.application.UUID
+import dk.cachet.carp.common.application.users.AccountIdentity
+import dk.cachet.carp.webservices.account.service.AccountService
+import dk.cachet.carp.webservices.account.service.impl.CoreAccountService
+import dk.cachet.carp.webservices.common.email.listener.EmailSendingJob
+import dk.cachet.carp.webservices.common.email.service.EmailInvitationService
+import dk.cachet.carp.webservices.common.email.service.impl.javamail.EmailServiceImpl
+import dk.cachet.carp.webservices.common.email.util.EmailTemplateUtil
+import dk.cachet.carp.webservices.common.email.util.EmailValidatorUtil
+import dk.cachet.carp.webservices.deployment.repository.CoreDeploymentRepository
+import dk.cachet.carp.webservices.security.authentication.domain.Account
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import kotlin.test.expect
+
+class EmailInvitationServiceImplTest {
+    private val emailValidator: EmailValidatorUtil = mockk()
+    private val emailTemplate: EmailTemplateUtil = mockk()
+    private val emailService: EmailServiceImpl = mockk()
+    private val emailSendingJob: EmailSendingJob = mockk()
+
+    @Nested
+    inner class inviteToStudy {
+        @Test
+        fun `should not throw if email address is invalid`() =
+            runTest {
+                val sut = EmailInvitationServiceImpl(emailValidator, emailTemplate, emailService, emailSendingJob);
+                coEvery { emailValidator.isValid("invalid-email") } returns false
+
+                sut.inviteToStudy("invalid-email", UUID.randomUUID(), mockk(), mockk())
+
+                coVerify(exactly = 0) { emailSendingJob.send(any()) }
+            }
+    }
+}

--- a/src/test/kotlin/dk/cachet/carp/webservices/common/email/service/impl/EmailInvitationServiceImplTest.kt
+++ b/src/test/kotlin/dk/cachet/carp/webservices/common/email/service/impl/EmailInvitationServiceImplTest.kt
@@ -1,25 +1,16 @@
 package dk.cachet.carp.webservices.common.email.service.impl
 
 import dk.cachet.carp.common.application.UUID
-import dk.cachet.carp.common.application.users.AccountIdentity
-import dk.cachet.carp.webservices.account.service.AccountService
-import dk.cachet.carp.webservices.account.service.impl.CoreAccountService
 import dk.cachet.carp.webservices.common.email.listener.EmailSendingJob
-import dk.cachet.carp.webservices.common.email.service.EmailInvitationService
 import dk.cachet.carp.webservices.common.email.service.impl.javamail.EmailServiceImpl
 import dk.cachet.carp.webservices.common.email.util.EmailTemplateUtil
 import dk.cachet.carp.webservices.common.email.util.EmailValidatorUtil
-import dk.cachet.carp.webservices.deployment.repository.CoreDeploymentRepository
-import dk.cachet.carp.webservices.security.authentication.domain.Account
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
-import kotlin.test.expect
+import org.junit.jupiter.api.Test
 
 class EmailInvitationServiceImplTest {
     private val emailValidator: EmailValidatorUtil = mockk()
@@ -32,7 +23,7 @@ class EmailInvitationServiceImplTest {
         @Test
         fun `should not throw if email address is invalid`() =
             runTest {
-                val sut = EmailInvitationServiceImpl(emailValidator, emailTemplate, emailService, emailSendingJob);
+                val sut = EmailInvitationServiceImpl(emailValidator, emailTemplate, emailService, emailSendingJob)
                 coEvery { emailValidator.isValid("invalid-email") } returns false
 
                 sut.inviteToStudy("invalid-email", UUID.randomUUID(), mockk(), mockk())


### PR DESCRIPTION
currently when we try to send an email using EmailInvitationServiceImpl.java class, if the email is invalid it will throw. I changed so that it only logs a WARN. This is because in dk.cachet.carp.deployments.domain.users.ParticipantGroupService#createAndInviteParticipantGroup we have a loop that does not handle exceptions if one the emails failed to be sent.

nothing was changed regarding keycloak as keycloak will still manage to create the user with a broken email (the keycloak email sending will not throw)