### PR TITLE
replaced throw with warn

### DIFF
--- a/src/main/kotlin/dk/cachet/carp/webservices/datastream/service/core/CoreDataStreamService.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/datastream/service/core/CoreDataStreamService.kt
@@ -113,10 +113,12 @@ class CoreDataStreamService(
                 configRepository.getConfigurationsForIds(studyDeploymentIds.map { it.stringRepresentation })
             }
 
-        // TODO: warn instead of throwing exception
-        require(configs.size == studyDeploymentIds.size) { "One of the configurations passed is not valid." }
-
         configs.forEach { it.closed = true }
+
+        if (configs.size != studyDeploymentIds.size) {
+            LOGGER.warn("While closing configurations: Number of deployments different from number of configurations")
+        }
+
         configRepository.saveAll(configs)
     }
 

--- a/src/test/kotlin/dk/cachet/carp/webservices/datastream/service/core/CoreDataStreamServiceTest.kt
+++ b/src/test/kotlin/dk/cachet/carp/webservices/datastream/service/core/CoreDataStreamServiceTest.kt
@@ -294,19 +294,5 @@ class CoreDataStreamServiceTest {
                 coVerify { config2.closed = true }
                 coVerify { configRepository.saveAll(listOf(config1, config2)) }
             }
-
-        @Test
-        fun `throw IllegalArgumentException when configuration does not exist`() =
-            runTest {
-                val studyDeploymentId = UUID.randomUUID()
-
-                coEvery {
-                    configRepository.getConfigurationsForIds(listOf(studyDeploymentId.stringRepresentation))
-                } returns emptyList()
-
-                assertThrows<IllegalArgumentException> {
-                    sut.closeDataStreams(setOf(studyDeploymentId))
-                }
-            }
     }
 }


### PR DESCRIPTION
https://github.com/orgs/cph-cachet/projects/9?pane=issue&itemId=79920736&issue=cph-cachet%7Ccarp-webservices-spring%7C138

currently, when closing the data stream, it will throw if nr of deployments for a study is diff from nr of the data stream configuration. This is a problem since when no devices are added, the nr of data stream configurations in 0 so it will throw. I changed it to a warn instead. 