### PR TITLE
Move Instant and Clock from kotlinx.datetime to kotlin.time

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ springDependencyManagementVersion=1.1.7
 springMockkVersion=5.0.1
 
 kotlinVersion=2.4.0
-kotlinDatetimeVersion=0.6.1
+kotlinDatetimeVersion=0.8.0
 serializationJSONVersion=1.11.0
 detektVersion=1.23.8
 ktlintVersion=12.2.0

--- a/src/main/kotlin/dk/cachet/carp/webservices/common/converter/ISO8601ToKotlinInstantConverter.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/common/converter/ISO8601ToKotlinInstantConverter.kt
@@ -1,7 +1,7 @@
 package dk.cachet.carp.webservices.common.converter
 
-import kotlinx.datetime.Instant
 import org.springframework.core.convert.converter.Converter
+import kotlin.time.Instant
 
 class ISO8601ToKotlinInstantConverter : Converter<String, Instant> {
     override fun convert(source: String): Instant {

--- a/src/main/kotlin/dk/cachet/carp/webservices/common/input/domain/Diagnosis.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/common/input/domain/Diagnosis.kt
@@ -2,9 +2,9 @@ package dk.cachet.carp.webservices.common.input.domain
 
 import dk.cachet.carp.common.application.data.Data
 import dk.cachet.carp.webservices.common.input.WSInputDataTypes
-import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlin.time.Instant
 
 /**
  * Represents a diagnosis of a participant.

--- a/src/main/kotlin/dk/cachet/carp/webservices/common/input/domain/HandedOutDevice.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/common/input/domain/HandedOutDevice.kt
@@ -2,10 +2,10 @@ package dk.cachet.carp.webservices.common.input.domain
 
 import dk.cachet.carp.common.application.data.Data
 import dk.cachet.carp.webservices.common.input.WSInputDataTypes
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlin.time.Clock
+import kotlin.time.Instant
 
 /**
  * Information about devices handed out to a participant.

--- a/src/main/kotlin/dk/cachet/carp/webservices/common/input/domain/InformedConsent.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/common/input/domain/InformedConsent.kt
@@ -2,10 +2,10 @@ package dk.cachet.carp.webservices.common.input.domain
 
 import dk.cachet.carp.common.application.data.Data
 import dk.cachet.carp.webservices.common.input.WSInputDataTypes
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlin.time.Clock
+import kotlin.time.Instant
 
 /**
  * The informed consent from a participant.

--- a/src/main/kotlin/dk/cachet/carp/webservices/common/serialisers/ObjectMapperConfig.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/common/serialisers/ObjectMapperConfig.kt
@@ -13,7 +13,6 @@ import dk.cachet.carp.webservices.common.configuration.internationalisation.serv
 import dk.cachet.carp.webservices.common.serialisers.serdes.UUIDDeserializer
 import dk.cachet.carp.webservices.common.serialisers.serdes.UUIDSerializer
 import dk.cachet.carp.webservices.datastream.serdes.*
-import kotlinx.datetime.Instant
 import org.springframework.boot.jackson.autoconfigure.JsonMapperBuilderCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -22,6 +21,7 @@ import tools.jackson.databind.SerializationContext
 import tools.jackson.databind.ValueSerializer
 import tools.jackson.databind.module.SimpleModule
 import tools.jackson.module.kotlin.KotlinModule
+import kotlin.time.Instant
 
 /**
  * The Configuration Class [ObjectMapperConfig].

--- a/src/main/kotlin/dk/cachet/carp/webservices/datastream/controller/DataStreamController.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/datastream/controller/DataStreamController.kt
@@ -7,13 +7,13 @@ import dk.cachet.carp.webservices.datastream.dto.DataStreamsSummaryDto
 import dk.cachet.carp.webservices.datastream.service.DataStreamService
 import dk.cachet.carp.webservices.datastream.service.impl.decompressGzip
 import io.swagger.v3.oas.annotations.Operation
-import kotlinx.datetime.Instant
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
+import kotlin.time.Instant
 
 @RestController
 class DataStreamController(

--- a/src/main/kotlin/dk/cachet/carp/webservices/datastream/domain/DateTaskQuantityTriple.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/datastream/domain/DateTaskQuantityTriple.kt
@@ -1,6 +1,6 @@
 package dk.cachet.carp.webservices.datastream.domain
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 data class DateTaskQuantityTriple(
     val date: Instant,

--- a/src/main/kotlin/dk/cachet/carp/webservices/datastream/dto/DataStreamsSummaryDto.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/datastream/dto/DataStreamsSummaryDto.kt
@@ -1,7 +1,7 @@
 package dk.cachet.carp.webservices.datastream.dto
 
 import dk.cachet.carp.webservices.datastream.domain.DateTaskQuantityTriple
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 data class DataStreamsSummaryDto(
     val data: List<DateTaskQuantityTriple>,

--- a/src/main/kotlin/dk/cachet/carp/webservices/datastream/service/DataStreamService.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/datastream/service/DataStreamService.kt
@@ -3,7 +3,7 @@ package dk.cachet.carp.webservices.datastream.service
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.data.infrastructure.DataStreamServiceDecorator
 import dk.cachet.carp.webservices.datastream.dto.DataStreamsSummaryDto
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 interface DataStreamService {
     val core: DataStreamServiceDecorator

--- a/src/main/kotlin/dk/cachet/carp/webservices/datastream/service/impl/DataStreamService.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/datastream/service/impl/DataStreamService.kt
@@ -16,9 +16,6 @@ import dk.cachet.carp.webservices.datastream.service.createSequence
 import dk.cachet.carp.webservices.deployment.service.ParticipationService
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Instant
-import kotlinx.datetime.toJavaInstant
-import kotlinx.datetime.toKotlinInstant
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import org.springframework.dao.DataAccessException
@@ -29,6 +26,9 @@ import tools.jackson.databind.ObjectMapper
 import java.io.IOException
 import java.nio.file.Path
 import java.time.ZoneOffset
+import kotlin.time.Instant
+import kotlin.time.toJavaInstant
+import kotlin.time.toKotlinInstant
 import dk.cachet.carp.webservices.datastream.domain.DataStreamId as DataStreamIdEntity
 
 @Service

--- a/src/main/kotlin/dk/cachet/carp/webservices/export/command/ExportCommand.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/export/command/ExportCommand.kt
@@ -14,14 +14,14 @@ import dk.cachet.carp.webservices.export.service.ResourceExporterService
 import dk.cachet.carp.webservices.file.util.FileUtil
 import dk.cachet.carp.webservices.study.domain.AnonymousParticipantRequest
 import dk.cachet.carp.webservices.study.service.AnonymousService
-import kotlinx.datetime.Clock
-import kotlinx.datetime.toJavaInstant
 import org.springframework.stereotype.Service
 import java.nio.ByteBuffer
 import java.nio.file.Path
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
+import kotlin.time.Clock
+import kotlin.time.toJavaInstant
 
 /**
  * A command to encapsulate the logic for long-running exports.

--- a/src/main/kotlin/dk/cachet/carp/webservices/export/command/impl/ExportAnonymousParticipants.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/export/command/impl/ExportAnonymousParticipants.kt
@@ -18,14 +18,14 @@ import dk.cachet.carp.webservices.study.domain.AnonymousParticipantRequest
 import dk.cachet.carp.webservices.study.service.AnonymousService
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Clock
-import kotlinx.datetime.toJavaInstant
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import java.nio.file.Path
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
+import kotlin.time.toJavaInstant
 
 /**
  * Generates anonymous participants for a study and writes their magic links to a CSV export.

--- a/src/main/kotlin/dk/cachet/carp/webservices/protocol/dto/ProtocolOverview.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/protocol/dto/ProtocolOverview.kt
@@ -1,8 +1,8 @@
 package dk.cachet.carp.webservices.protocol.dto
 
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
-import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
+import kotlin.time.Instant
 
 /**
  * A DTO representing the latest [StudyProtocolSnapshot] with auxiliary information.

--- a/src/main/kotlin/dk/cachet/carp/webservices/protocol/service/impl/ProtocolServiceWrapper.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/protocol/service/impl/ProtocolServiceWrapper.kt
@@ -14,8 +14,8 @@ import dk.cachet.carp.webservices.protocol.service.ProtocolService
 import dk.cachet.carp.webservices.security.authentication.domain.Account
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.toKotlinInstant
 import org.springframework.stereotype.Service
+import kotlin.time.toKotlinInstant
 
 @Service
 class ProtocolServiceWrapper(

--- a/src/main/kotlin/dk/cachet/carp/webservices/statistics/dto/StatisticsOverviewDto.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/statistics/dto/StatisticsOverviewDto.kt
@@ -1,6 +1,6 @@
 package dk.cachet.carp.webservices.statistics.dto
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 data class StatisticsOverviewDto(
     val totalLiveStudies: Long,

--- a/src/main/kotlin/dk/cachet/carp/webservices/statistics/service/impl/StatisticsServiceImpl.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/statistics/service/impl/StatisticsServiceImpl.kt
@@ -12,11 +12,11 @@ import dk.cachet.carp.webservices.statistics.service.StatisticsService
 import dk.cachet.carp.webservices.study.repository.StudyRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.toKotlinInstant
 import org.springframework.stereotype.Service
 import java.time.Clock
 import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
+import kotlin.time.toKotlinInstant
 
 @Service
 class StatisticsServiceImpl(

--- a/src/main/kotlin/dk/cachet/carp/webservices/study/domain/AnonymousParticipant.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/study/domain/AnonymousParticipant.kt
@@ -1,7 +1,7 @@
 package dk.cachet.carp.webservices.study.domain
 
 import dk.cachet.carp.common.application.UUID
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 data class AnonymousParticipant(
     val username: UUID,

--- a/src/main/kotlin/dk/cachet/carp/webservices/study/domain/ParticipantGroupsStatus.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/study/domain/ParticipantGroupsStatus.kt
@@ -6,8 +6,8 @@ import dk.cachet.carp.deployments.application.StudyDeploymentStatus
 import dk.cachet.carp.studies.application.users.Participant
 import dk.cachet.carp.studies.application.users.ParticipantGroupStatus
 import dk.cachet.carp.webservices.security.authentication.domain.Account
-import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
+import kotlin.time.Instant
 
 @Serializable
 data class ParticipantGroupsStatus(

--- a/src/main/kotlin/dk/cachet/carp/webservices/study/domain/StudyOverview.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/study/domain/StudyOverview.kt
@@ -1,7 +1,7 @@
 package dk.cachet.carp.webservices.study.domain
 
 import dk.cachet.carp.common.application.UUID
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 data class StudyOverview(
     /** StudyStatus */

--- a/src/main/kotlin/dk/cachet/carp/webservices/study/dto/ParticipantAccountSummaryDto.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/study/dto/ParticipantAccountSummaryDto.kt
@@ -1,6 +1,6 @@
 package dk.cachet.carp.webservices.study.dto
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 /**
  * Participant-centered row returned by the participant accounts query endpoint.

--- a/src/main/kotlin/dk/cachet/carp/webservices/study/service/impl/RecruitmentServiceWrapper.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/study/service/impl/RecruitmentServiceWrapper.kt
@@ -21,17 +21,17 @@ import dk.cachet.carp.webservices.study.repository.ParticipantAccountQueryRow
 import dk.cachet.carp.webservices.study.repository.RecruitmentRepository
 import dk.cachet.carp.webservices.study.service.RecruitmentService
 import kotlinx.coroutines.*
-import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
-import kotlinx.datetime.Instant
 import kotlinx.datetime.minus
-import kotlinx.datetime.toJavaInstant
-import kotlinx.datetime.toKotlinInstant
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import org.springframework.stereotype.Service
 import tools.jackson.core.type.TypeReference
 import tools.jackson.databind.ObjectMapper
+import kotlin.time.Clock
+import kotlin.time.Instant
+import kotlin.time.toJavaInstant
+import kotlin.time.toKotlinInstant
 
 @Service
 class RecruitmentServiceWrapper(

--- a/src/main/kotlin/dk/cachet/carp/webservices/study/service/impl/StudyServiceWrapper.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/study/service/impl/StudyServiceWrapper.kt
@@ -59,7 +59,7 @@ class StudyServiceWrapper(
                         studyId = status.studyId,
                         name = status.name,
                         createdOn =
-                            kotlinx.datetime.Instant.fromEpochSeconds(
+                            kotlin.time.Instant.fromEpochSeconds(
                                 status.createdOn.epochSeconds,
                                 status.createdOn.nanosecondsOfSecond.toLong(),
                             ),

--- a/src/test/kotlin/dk/cachet/carp/webservices/common/input/WSInputDataTypesSerializationTest.kt
+++ b/src/test/kotlin/dk/cachet/carp/webservices/common/input/WSInputDataTypesSerializationTest.kt
@@ -3,11 +3,11 @@ package dk.cachet.carp.webservices.common.input
 import dk.cachet.carp.common.application.data.Data
 import dk.cachet.carp.common.application.data.input.Sex
 import dk.cachet.carp.webservices.common.input.domain.*
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.serialization.PolymorphicSerializer
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Instant
 
 class WSInputDataTypesSerializationTest {
     @Suppress("LongMethod")

--- a/src/test/kotlin/dk/cachet/carp/webservices/datastream/service/impl/DataStreamServiceTest.kt
+++ b/src/test/kotlin/dk/cachet/carp/webservices/datastream/service/impl/DataStreamServiceTest.kt
@@ -30,8 +30,6 @@ import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Instant
-import kotlinx.datetime.toJavaInstant
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -53,6 +51,8 @@ import kotlin.random.Random
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
+import kotlin.time.Instant
+import kotlin.time.toJavaInstant
 import dk.cachet.carp.webservices.datastream.domain.DataStreamSequence as DataStreamSequenceEntity
 
 private const val SHARED_STREAM_ID = 100

--- a/src/test/kotlin/dk/cachet/carp/webservices/statistics/controller/StatisticsControllerTest.kt
+++ b/src/test/kotlin/dk/cachet/carp/webservices/statistics/controller/StatisticsControllerTest.kt
@@ -9,7 +9,6 @@ import dk.cachet.carp.webservices.statistics.service.StatisticsService
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.Instant
 import org.springframework.http.MediaType
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 import org.springframework.test.web.servlet.MockMvc
@@ -21,6 +20,7 @@ import tools.jackson.databind.module.SimpleModule
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Instant
 
 class StatisticsControllerTest {
     private val statisticsService: StatisticsService = mockk()

--- a/src/test/kotlin/dk/cachet/carp/webservices/statistics/service/impl/StatisticsServiceImplTest.kt
+++ b/src/test/kotlin/dk/cachet/carp/webservices/statistics/service/impl/StatisticsServiceImplTest.kt
@@ -22,7 +22,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
 import kotlin.test.assertEquals
-import kotlinx.datetime.Instant as KInstant
+import kotlin.time.Instant as KInstant
 
 class StatisticsServiceImplTest {
     private val studyRepository = mockk<StudyRepository>()

--- a/src/test/kotlin/dk/cachet/carp/webservices/study/service/impl/RecruitmentServiceWrapperTest.kt
+++ b/src/test/kotlin/dk/cachet/carp/webservices/study/service/impl/RecruitmentServiceWrapperTest.kt
@@ -21,12 +21,11 @@ import dk.cachet.carp.webservices.study.repository.ParticipantAccountQueryRow
 import dk.cachet.carp.webservices.study.repository.RecruitmentRepository
 import io.mockk.*
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.Instant
 import org.junit.jupiter.api.Nested
 import tools.jackson.core.type.TypeReference
 import tools.jackson.databind.ObjectMapper
 import kotlin.test.*
-import kotlin.time.Instant as CoreInstant
+import kotlin.time.Instant
 
 private fun participantGroupStatus(
     participants: Set<Participant>,
@@ -414,7 +413,7 @@ class RecruitmentServiceWrapperTest {
                     listOf(
                         mockk<StudyDeploymentStatus.Invited>().apply {
                             every { studyDeploymentId } returns deploymentId
-                            every { createdOn } returns CoreInstant.parse(invitedOn.toString())
+                            every { createdOn } returns Instant.parse(invitedOn.toString())
                         },
                     )
 
@@ -473,7 +472,7 @@ class RecruitmentServiceWrapperTest {
                     listOf(
                         mockk<StudyDeploymentStatus.Invited>().apply {
                             every { studyDeploymentId } returns deploymentId
-                            every { createdOn } returns CoreInstant.parse(invitedOn.toString())
+                            every { createdOn } returns Instant.parse(invitedOn.toString())
                         },
                     )
 
@@ -670,8 +669,8 @@ class RecruitmentServiceWrapperTest {
                         setOf(p1),
                         mockk<StudyDeploymentStatus.Invited>().apply {
                             every { studyDeploymentId } returns UUID.randomUUID()
-                            every { createdOn } returns CoreInstant.fromEpochSeconds(0)
-                            every { startedOn } returns CoreInstant.fromEpochSeconds(0)
+                            every { createdOn } returns Instant.fromEpochSeconds(0)
+                            every { startedOn } returns Instant.fromEpochSeconds(0)
                         },
                     )
                 val a1 = Account(email = eai1.emailAddress.address)
@@ -718,8 +717,8 @@ class RecruitmentServiceWrapperTest {
                         setOf(p1, p2),
                         mockk<StudyDeploymentStatus.Invited>().apply {
                             every { studyDeploymentId } returns mockDeploymentId
-                            every { createdOn } returns CoreInstant.fromEpochSeconds(0)
-                            every { startedOn } returns CoreInstant.fromEpochSeconds(0)
+                            every { createdOn } returns Instant.fromEpochSeconds(0)
+                            every { startedOn } returns Instant.fromEpochSeconds(0)
                         },
                     )
 
@@ -759,8 +758,8 @@ class RecruitmentServiceWrapperTest {
                         setOf(p1),
                         mockk<StudyDeploymentStatus.Invited>().apply {
                             every { studyDeploymentId } returns UUID.randomUUID()
-                            every { createdOn } returns CoreInstant.fromEpochSeconds(0)
-                            every { startedOn } returns CoreInstant.fromEpochSeconds(0)
+                            every { createdOn } returns Instant.fromEpochSeconds(0)
+                            every { startedOn } returns Instant.fromEpochSeconds(0)
                         },
                     )
 
@@ -831,8 +830,8 @@ class RecruitmentServiceWrapperTest {
                         setOf(p1),
                         mockk<StudyDeploymentStatus.Invited>().apply {
                             every { studyDeploymentId } returns mockDeploymentId
-                            every { createdOn } returns CoreInstant.fromEpochSeconds(0)
-                            every { startedOn } returns CoreInstant.fromEpochSeconds(0)
+                            every { createdOn } returns Instant.fromEpochSeconds(0)
+                            every { startedOn } returns Instant.fromEpochSeconds(0)
                         },
                     )
 
@@ -873,8 +872,8 @@ class RecruitmentServiceWrapperTest {
                         setOf(p1, p2),
                         mockk<StudyDeploymentStatus.Invited>().apply {
                             every { studyDeploymentId } returns mockDeploymentId
-                            every { createdOn } returns CoreInstant.fromEpochSeconds(0)
-                            every { startedOn } returns CoreInstant.fromEpochSeconds(0)
+                            every { createdOn } returns Instant.fromEpochSeconds(0)
+                            every { startedOn } returns Instant.fromEpochSeconds(0)
                         },
                     )
 
@@ -908,8 +907,8 @@ class RecruitmentServiceWrapperTest {
                 val mockSds =
                     mockk<StudyDeploymentStatus.Invited>().apply {
                         every { studyDeploymentId } returns mockGroupId
-                        every { createdOn } returns CoreInstant.fromEpochSeconds(0)
-                        every { startedOn } returns CoreInstant.fromEpochSeconds(0)
+                        every { createdOn } returns Instant.fromEpochSeconds(0)
+                        every { startedOn } returns Instant.fromEpochSeconds(0)
                     }
                 val pg = participantGroupStatus(emptySet(), mockSds)
 


### PR DESCRIPTION
kotlinx-datetime 0.7.0+ relocated Instant and Clock to the kotlin.time stdlib package (stable since Kotlin 2.3). Bump the dependency to 0.8.0, aligning with what carp.core 1.3.0 already declares (was force-downgraded to 0.6.1), and migrate all Instant/Clock imports plus the toJavaInstant/ toKotlinInstant converters. LocalDate, DateTimeUnit, and minus stay in kotlinx.datetime; java.time usages are untouched.