### PR TITLE
Add participant-group status counts endpoint and pagination

### DIFF
--- a/src/main/kotlin/dk/cachet/carp/webservices/common/constants/RequestParamName.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/common/constants/RequestParamName.kt
@@ -9,6 +9,8 @@ object RequestParamName {
     const val QUERY = "query"
     const val SORT = "sort"
     const val PAGE = "page"
+    const val SIZE = "size"
+    const val STATUS = "status"
     const val EMAIL = "email"
     const val ROLE = "role"
     const val OFFSET = "offset"

--- a/src/main/kotlin/dk/cachet/carp/webservices/study/controller/StudyController.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/study/controller/StudyController.kt
@@ -7,6 +7,7 @@ import dk.cachet.carp.studies.infrastructure.StudyServiceRequest
 import dk.cachet.carp.webservices.account.service.AccountService
 import dk.cachet.carp.webservices.common.constants.PathVariableName
 import dk.cachet.carp.webservices.common.constants.RequestParamName
+import dk.cachet.carp.webservices.common.exception.responses.BadRequestException
 import dk.cachet.carp.webservices.common.input.WS_JSON
 import dk.cachet.carp.webservices.common.serialisers.ApplicationRequestSerializer
 import dk.cachet.carp.webservices.security.authentication.domain.Account
@@ -17,6 +18,7 @@ import dk.cachet.carp.webservices.study.domain.InactiveDeploymentInfo
 import dk.cachet.carp.webservices.study.domain.ParticipantGroupsStatus
 import dk.cachet.carp.webservices.study.domain.StudyOverview
 import dk.cachet.carp.webservices.study.dto.AddParticipantsRequestDto
+import dk.cachet.carp.webservices.study.dto.DeploymentStatusCountsDto
 import dk.cachet.carp.webservices.study.dto.ParticipantAccountsRequestDto
 import dk.cachet.carp.webservices.study.dto.ParticipantAccountsResponseDto
 import dk.cachet.carp.webservices.study.serdes.RecruitmentRequestSerializer
@@ -55,6 +57,7 @@ class StudyController(
         const val GET_STUDIES_OVERVIEW = "/api/studies/studies-overview"
         const val PARTICIPANTS_ACCOUNTS = "/api/studies/{${PathVariableName.STUDY_ID}}/participants/accounts"
         const val GET_PARTICIPANT_GROUP_STATUS = "/api/studies/{${PathVariableName.STUDY_ID}}/participantGroup/status"
+        const val GET_PARTICIPANT_GROUP_COUNTS = "/api/studies/{${PathVariableName.STUDY_ID}}/participantGroup/counts"
         const val ADD_PARTICIPANTS = "/api/studies/{${PathVariableName.STUDY_ID}}/participants/add"
         const val GET_INACTIVE_DEPLOYMENTS = "/api/studies/{${PathVariableName.STUDY_ID}}/inactive_deployments"
     }
@@ -111,12 +114,47 @@ class StudyController(
     @GetMapping(value = [GET_PARTICIPANT_GROUP_STATUS])
     @PreAuthorize("canManageStudy(#studyId) or canLimitedManageStudy(#studyId)")
     @ResponseStatus(HttpStatus.OK)
+    @Operation(
+        summary = "Participant group status",
+        description =
+            "Returns participant-group deployment status for a study. When both page and size are " +
+                "given, returns one page of matching groups plus a total; otherwise returns all groups. " +
+                "Supports search (deployment id / account identity) and a status filter.",
+    )
     suspend fun getParticipantGroupStatus(
         @PathVariable(PathVariableName.STUDY_ID) studyId: UUID,
+        @RequestParam(name = RequestParamName.PAGE, required = false) page: Int?,
+        @RequestParam(name = RequestParamName.SIZE, required = false) size: Int?,
+        @RequestParam(name = RequestParamName.QUERY, required = false) search: String?,
+        @RequestParam(name = RequestParamName.STATUS, required = false) status: String?,
     ): String {
         LOGGER.info("Start GET: /api/studies/$studyId/participantGroup/status")
-        val result = recruitmentService.getParticipantGroupsStatus(studyId)
+        // Pagination is opt-in but must be well-formed: both params together, page >= 0, size >= 1.
+        if ((page == null) != (size == null)) {
+            throw BadRequestException("'page' and 'size' must be provided together, or neither.")
+        }
+        if (page != null && page < 0) {
+            throw BadRequestException(RequestParamName.PAGE, page.toString())
+        }
+        if (size != null && size < 1) {
+            throw BadRequestException(RequestParamName.SIZE, size.toString())
+        }
+        val result = recruitmentService.getParticipantGroupsStatus(studyId, page, size, search, status)
         return WS_JSON.encodeToString(ParticipantGroupsStatus.serializer(), result)
+    }
+
+    @GetMapping(value = [GET_PARTICIPANT_GROUP_COUNTS])
+    @PreAuthorize("canManageStudy(#studyId) or canLimitedManageStudy(#studyId)")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(
+        summary = "Participant group status counts",
+        description = "Aggregate counts of participant-group deployment statuses for the study overview.",
+    )
+    suspend fun getParticipantGroupCounts(
+        @PathVariable(PathVariableName.STUDY_ID) studyId: UUID,
+    ): DeploymentStatusCountsDto {
+        LOGGER.info("Start GET: /api/studies/$studyId/participantGroup/counts")
+        return recruitmentService.getParticipantGroupStatusCounts(studyId)
     }
 
     @DeleteMapping(value = [RESEARCHERS])

--- a/src/main/kotlin/dk/cachet/carp/webservices/study/domain/ParticipantGroupsStatus.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/study/domain/ParticipantGroupsStatus.kt
@@ -13,6 +13,8 @@ import kotlin.time.Instant
 data class ParticipantGroupsStatus(
     val groups: List<ParticipantGroupInfo>,
     val groupStatuses: List<ParticipantGroupStatus>,
+    // Total number of matching participant groups before paging. Null for unpaged (legacy) calls.
+    val total: Int? = null,
 )
 
 @Serializable

--- a/src/main/kotlin/dk/cachet/carp/webservices/study/dto/DeploymentStatusCountsDto.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/study/dto/DeploymentStatusCountsDto.kt
@@ -1,0 +1,16 @@
+package dk.cachet.carp.webservices.study.dto
+
+/**
+ * Aggregate counts of a study's participant-group deployment statuses.
+ *
+ * Powers the study overview pie chart without shipping the full participant-group status list to the
+ * client. The four buckets count groups that are in a deployment, by deployment state; [total] is the
+ * total number of participant groups (matching the pie's center label).
+ */
+data class DeploymentStatusCountsDto(
+    val invited: Int,
+    val deployingDevices: Int,
+    val running: Int,
+    val stopped: Int,
+    val total: Int,
+)

--- a/src/main/kotlin/dk/cachet/carp/webservices/study/service/RecruitmentService.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/study/service/RecruitmentService.kt
@@ -8,6 +8,7 @@ import dk.cachet.carp.webservices.security.authorization.Role
 import dk.cachet.carp.webservices.study.domain.InactiveDeploymentInfo
 import dk.cachet.carp.webservices.study.domain.ParticipantGroupsStatus
 import dk.cachet.carp.webservices.study.domain.ParticipantOrderBy
+import dk.cachet.carp.webservices.study.dto.DeploymentStatusCountsDto
 import dk.cachet.carp.webservices.study.dto.ParticipantAccountsRequestDto
 import dk.cachet.carp.webservices.study.dto.ParticipantAccountsResponseDto
 
@@ -47,7 +48,25 @@ interface RecruitmentService {
         limit: Int = -1,
     ): List<InactiveDeploymentInfo>
 
-    suspend fun getParticipantGroupsStatus(studyId: UUID): ParticipantGroupsStatus
+    /**
+     * Paged, filterable participant-group status.
+     *
+     * When [page] and [size] are both provided, returns one page of matching groups plus the total
+     * count; when omitted, returns every group (legacy behavior). [search] matches deployment id and
+     * participant account identity; [status] filters by deployment state (e.g. "Running"). Only the
+     * returned page is enriched with account/last-upload data, so that work is O(page), not O(all).
+     */
+    @Suppress("LongParameterList")
+    suspend fun getParticipantGroupsStatus(
+        studyId: UUID,
+        page: Int? = null,
+        size: Int? = null,
+        search: String? = null,
+        status: String? = null,
+    ): ParticipantGroupsStatus
+
+    /** Aggregate counts of participant-group deployment statuses for the study overview pie chart. */
+    suspend fun getParticipantGroupStatusCounts(studyId: UUID): DeploymentStatusCountsDto
 
     /**
      * Temporary workaround for a bug in carp.core 1.3.0 [RecruitmentServiceHost.stopParticipantGroup],

--- a/src/main/kotlin/dk/cachet/carp/webservices/study/service/impl/RecruitmentServiceWrapper.kt
+++ b/src/main/kotlin/dk/cachet/carp/webservices/study/service/impl/RecruitmentServiceWrapper.kt
@@ -4,6 +4,7 @@ import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.users.AccountIdentity
 import dk.cachet.carp.common.application.users.EmailAccountIdentity
 import dk.cachet.carp.common.application.users.UsernameAccountIdentity
+import dk.cachet.carp.deployments.application.StudyDeploymentStatus
 import dk.cachet.carp.studies.application.users.Participant
 import dk.cachet.carp.studies.application.users.ParticipantGroupStatus
 import dk.cachet.carp.webservices.account.service.AccountService
@@ -14,6 +15,7 @@ import dk.cachet.carp.webservices.security.authorization.Claim
 import dk.cachet.carp.webservices.security.authorization.Role
 import dk.cachet.carp.webservices.security.config.SecurityCoroutineContext
 import dk.cachet.carp.webservices.study.domain.*
+import dk.cachet.carp.webservices.study.dto.DeploymentStatusCountsDto
 import dk.cachet.carp.webservices.study.dto.ParticipantAccountSummaryDto
 import dk.cachet.carp.webservices.study.dto.ParticipantAccountsRequestDto
 import dk.cachet.carp.webservices.study.dto.ParticipantAccountsResponseDto
@@ -240,62 +242,156 @@ class RecruitmentServiceWrapper(
                 .map { InactiveDeploymentInfo(UUID(it.deploymentId), it.lastDataUpload.toKotlinInstant()) }
         }
 
-    override suspend fun getParticipantGroupsStatus(studyId: UUID): ParticipantGroupsStatus =
+    override suspend fun getParticipantGroupsStatus(
+        studyId: UUID,
+        page: Int?,
+        size: Int?,
+        search: String?,
+        status: String?,
+    ): ParticipantGroupsStatus =
         withContext(Dispatchers.IO + SecurityCoroutineContext()) {
-            val participantGroupStatusList = core.getParticipantGroupStatusList(studyId)
+            val allStatuses = core.getParticipantGroupStatusList(studyId)
+
+            // Filtering/searching run against the core status list (deployment state + account identity
+            // from the recruitment snapshot), so deciding which rows match needs no Keycloak or
+            // data-stream calls.
+            var matched = allStatuses.filterIsInstance<ParticipantGroupStatus.InDeployment>()
+            if (!status.isNullOrBlank()) {
+                matched = matched.filter { it.studyDeploymentStatus.matchesStateName(status) }
+            }
+            if (!search.isNullOrBlank()) {
+                val needle = search.lowercase()
+                matched = matched.filter { it.matchesSearch(needle) }
+            }
+
+            val paginating = page != null && size != null
+            // A completely unfiltered, unpaged call is the legacy contract that returns everything.
+            val isLegacyUnfiltered =
+                !paginating && search.isNullOrBlank() && status.isNullOrBlank()
+            val total = matched.size
+
+            // Enrich ONLY the requested page — the expensive per-group account resolution and
+            // last-upload lookup become O(page) instead of O(all). Offset is computed as Long so a
+            // large page * size can't overflow Int and wrap back to an earlier page; an offset past
+            // the end yields an empty page.
+            val pageOfGroups =
+                if (paginating) {
+                    val offset = page.toLong() * size.toLong()
+                    if (offset >= matched.size) emptyList() else matched.drop(offset.toInt()).take(size)
+                } else {
+                    matched
+                }
             val lastUploadByDeployment = mutableMapOf<UUID, Instant?>()
+            val participantGroupInfoList = pageOfGroups.map { enrichGroup(it, lastUploadByDeployment) }
 
-            val participantGroupInfoList =
-                participantGroupStatusList
-                    .filterIsInstance<ParticipantGroupStatus.InDeployment>()
-                    .map { groupStatus ->
-                        val accountsByParticipant =
-                            groupStatus.participants.associateWith { participant ->
-                                // Generated (anonymous) accounts are username-only with no name/email to
-                                // enrich, and they always exist, so we resolve them locally instead of
-                                // making a Keycloak call per participant.
-                                // TODO(account-existence): local resolution ASSUMES the generated account
-                                //  exists rather than verifying it. See project_account_lookup_n1 for the
-                                //  long-term fix (per-study Keycloak group or a local participant read model).
-                                when (participant.accountIdentity) {
-                                    is UsernameAccountIdentity ->
-                                        Account.fromAccountIdentity(participant.accountIdentity)
-                                            .apply { role = Role.PARTICIPANT }
-                                    else -> accountService.findByAccountIdentity(participant.accountIdentity)
-                                }
-                            }
-
-                        val lastDataUpload =
-                            if (accountsByParticipant.values.any { it != null }) {
-                                lastUploadByDeployment.getOrPut(groupStatus.studyDeploymentStatus.studyDeploymentId) {
-                                    dataStreamService.getLatestUpdatedAt(
-                                        groupStatus.studyDeploymentStatus.studyDeploymentId,
-                                    )
-                                }
-                            } else {
-                                null
-                            }
-
-                        val participantAccounts =
-                            groupStatus.participants.map { participant ->
-                                val participantAccount = ParticipantAccount.fromParticipant(participant)
-                                val account = accountsByParticipant[participant]
-
-                                if (account != null) {
-                                    participantAccount.lateInitFrom(account)
-
-                                    // TODO: we cannot track this for participants, only for deployments
-                                    participantAccount.dateOfLastDataUpload = lastDataUpload
-                                }
-
-                                participantAccount
-                            }
-
-                        ParticipantGroupInfo(groupStatus.id, groupStatus.studyDeploymentStatus, participantAccounts)
-                    }
-
-            ParticipantGroupsStatus(participantGroupInfoList, participantGroupStatusList)
+            ParticipantGroupsStatus(
+                groups = participantGroupInfoList,
+                // Only the legacy unfiltered call keeps the full status list; as soon as the result is
+                // filtered/searched/paged, `groupStatuses` must mirror `groups` so the two collections
+                // never disagree (e.g. clients reading representation names off `groupStatuses`).
+                groupStatuses = if (isLegacyUnfiltered) allStatuses else pageOfGroups,
+                total = if (paginating) total else null,
+            )
         }
+
+    override suspend fun getParticipantGroupStatusCounts(studyId: UUID): DeploymentStatusCountsDto =
+        withContext(Dispatchers.IO + SecurityCoroutineContext()) {
+            val statuses = core.getParticipantGroupStatusList(studyId)
+            var invited = 0
+            var deployingDevices = 0
+            var running = 0
+            var stopped = 0
+            statuses.filterIsInstance<ParticipantGroupStatus.InDeployment>().forEach { group ->
+                when (group.studyDeploymentStatus) {
+                    is StudyDeploymentStatus.Invited -> invited++
+                    is StudyDeploymentStatus.DeployingDevices -> deployingDevices++
+                    is StudyDeploymentStatus.Running -> running++
+                    is StudyDeploymentStatus.Stopped -> stopped++
+                }
+            }
+            DeploymentStatusCountsDto(invited, deployingDevices, running, stopped, total = statuses.size)
+        }
+
+    /**
+     * Matches a deployment state against a status-name filter (e.g. "Running"). Uses type checks
+     * rather than reflecting on the class name so it is robust to minification/obfuscation.
+     */
+    private fun StudyDeploymentStatus.matchesStateName(name: String): Boolean =
+        when (this) {
+            is StudyDeploymentStatus.Invited -> name == "Invited"
+            is StudyDeploymentStatus.DeployingDevices -> name == "DeployingDevices"
+            is StudyDeploymentStatus.Running -> name == "Running"
+            is StudyDeploymentStatus.Stopped -> name == "Stopped"
+            else -> false
+        }
+
+    /** Matches a group against a lowercased search needle by deployment id or participant identity. */
+    private fun ParticipantGroupStatus.InDeployment.matchesSearch(needle: String): Boolean {
+        if (id.stringRepresentation.lowercase().contains(needle)) return true
+        if (studyDeploymentStatus.studyDeploymentId.stringRepresentation.lowercase().contains(needle)) {
+            return true
+        }
+        return participants.any { participant ->
+            when (val identity = participant.accountIdentity) {
+                is EmailAccountIdentity -> identity.emailAddress.address.lowercase().contains(needle)
+                is UsernameAccountIdentity -> identity.username.name.lowercase().contains(needle)
+                else -> false
+            }
+        }
+    }
+
+    /**
+     * Enriches a single in-deployment group with participant account data and the deployment's last
+     * upload time. Kept separate so callers can enrich just a page of groups rather than all of them.
+     */
+    private suspend fun enrichGroup(
+        groupStatus: ParticipantGroupStatus.InDeployment,
+        lastUploadByDeployment: MutableMap<UUID, Instant?>,
+    ): ParticipantGroupInfo {
+        val accountsByParticipant =
+            groupStatus.participants.associateWith { participant ->
+                // Generated (anonymous) accounts are username-only with no name/email to enrich, and
+                // they always exist, so we resolve them locally instead of making a Keycloak call per
+                // participant.
+                // TODO(account-existence): local resolution ASSUMES the generated account exists rather
+                //  than verifying it. See project_account_lookup_n1 for the long-term fix (per-study
+                //  Keycloak group or a local participant read model).
+                when (participant.accountIdentity) {
+                    is UsernameAccountIdentity ->
+                        Account.fromAccountIdentity(participant.accountIdentity)
+                            .apply { role = Role.PARTICIPANT }
+                    else -> accountService.findByAccountIdentity(participant.accountIdentity)
+                }
+            }
+
+        val lastDataUpload =
+            if (accountsByParticipant.values.any { it != null }) {
+                lastUploadByDeployment.getOrPut(groupStatus.studyDeploymentStatus.studyDeploymentId) {
+                    dataStreamService.getLatestUpdatedAt(
+                        groupStatus.studyDeploymentStatus.studyDeploymentId,
+                    )
+                }
+            } else {
+                null
+            }
+
+        val participantAccounts =
+            groupStatus.participants.map { participant ->
+                val participantAccount = ParticipantAccount.fromParticipant(participant)
+                val account = accountsByParticipant[participant]
+
+                if (account != null) {
+                    participantAccount.lateInitFrom(account)
+
+                    // TODO: we cannot track this for participants, only for deployments
+                    participantAccount.dateOfLastDataUpload = lastDataUpload
+                }
+
+                participantAccount
+            }
+
+        return ParticipantGroupInfo(groupStatus.id, groupStatus.studyDeploymentStatus, participantAccounts)
+    }
 
     override suspend fun stopParticipantGroup(
         studyId: UUID,

--- a/src/test/kotlin/dk/cachet/carp/webservices/study/controller/StudyControllerTest.kt
+++ b/src/test/kotlin/dk/cachet/carp/webservices/study/controller/StudyControllerTest.kt
@@ -2,7 +2,9 @@ package dk.cachet.carp.webservices.study.controller
 
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.webservices.account.service.AccountService
+import dk.cachet.carp.webservices.common.exception.responses.BadRequestException
 import dk.cachet.carp.webservices.security.authentication.service.AuthenticationService
+import dk.cachet.carp.webservices.study.domain.ParticipantGroupsStatus
 import dk.cachet.carp.webservices.study.dto.ParticipantAccountsResponseDto
 import dk.cachet.carp.webservices.study.service.RecruitmentService
 import dk.cachet.carp.webservices.study.service.StudyService
@@ -17,6 +19,7 @@ import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 
 class StudyControllerTest {
     private val authenticationService: AuthenticationService = mockk()
@@ -115,6 +118,102 @@ class StudyControllerTest {
                         content = """{"sortDirection":"asc"}"""
                     }.andExpect { status { isBadRequest() } }
                 coVerify(exactly = 0) { recruitmentService.queryParticipantAccounts(any(), any()) }
+            }
+        }
+    }
+
+    @Nested
+    inner class GetParticipantGroupStatus {
+        // The handler is a suspend function, so validation happens in the coroutine body; invoke it
+        // directly rather than through MockMvc (which would need async dispatch to observe the result).
+        private val controller =
+            StudyController(authenticationService, accountService, studyService, recruitmentService)
+
+        @Test
+        fun `rejects page without size`() {
+            runTest {
+                assertFailsWith<BadRequestException> {
+                    controller.getParticipantGroupStatus(
+                        UUID.randomUUID(),
+                        page = 0,
+                        size = null,
+                        search = null,
+                        status = null,
+                    )
+                }
+                coVerify(exactly = 0) {
+                    recruitmentService.getParticipantGroupsStatus(any(), any(), any(), any(), any())
+                }
+            }
+        }
+
+        @Test
+        fun `rejects size without page`() {
+            runTest {
+                assertFailsWith<BadRequestException> {
+                    controller.getParticipantGroupStatus(
+                        UUID.randomUUID(),
+                        page = null,
+                        size = 20,
+                        search = null,
+                        status = null,
+                    )
+                }
+                coVerify(exactly = 0) {
+                    recruitmentService.getParticipantGroupsStatus(any(), any(), any(), any(), any())
+                }
+            }
+        }
+
+        @Test
+        fun `rejects size below one`() {
+            runTest {
+                assertFailsWith<BadRequestException> {
+                    controller.getParticipantGroupStatus(
+                        UUID.randomUUID(),
+                        page = 0,
+                        size = 0,
+                        search = null,
+                        status = null,
+                    )
+                }
+                coVerify(exactly = 0) {
+                    recruitmentService.getParticipantGroupsStatus(any(), any(), any(), any(), any())
+                }
+            }
+        }
+
+        @Test
+        fun `rejects negative page`() {
+            runTest {
+                assertFailsWith<BadRequestException> {
+                    controller.getParticipantGroupStatus(
+                        UUID.randomUUID(),
+                        page = -1,
+                        size = 8,
+                        search = null,
+                        status = null,
+                    )
+                }
+                coVerify(exactly = 0) {
+                    recruitmentService.getParticipantGroupsStatus(any(), any(), any(), any(), any())
+                }
+            }
+        }
+
+        @Test
+        fun `accepts a valid page and size`() {
+            runTest {
+                val studyId = UUID.randomUUID()
+                coEvery {
+                    recruitmentService.getParticipantGroupsStatus(any(), any(), any(), any(), any())
+                } returns ParticipantGroupsStatus(emptyList(), emptyList(), 0)
+
+                controller.getParticipantGroupStatus(studyId, page = 0, size = 8, search = null, status = null)
+
+                coVerify(exactly = 1) {
+                    recruitmentService.getParticipantGroupsStatus(studyId, 0, 8, null, null)
+                }
             }
         }
     }

--- a/src/test/kotlin/dk/cachet/carp/webservices/study/service/impl/RecruitmentServiceWrapperTest.kt
+++ b/src/test/kotlin/dk/cachet/carp/webservices/study/service/impl/RecruitmentServiceWrapperTest.kt
@@ -38,6 +38,16 @@ private fun participantGroupStatus(
         ParticipantGroupRepresentation.Default,
     )
 
+private inline fun <reified T : StudyDeploymentStatus> statusMock(deploymentId: UUID = UUID.randomUUID()): T =
+    mockk<T>().apply {
+        every { studyDeploymentId } returns deploymentId
+        every { createdOn } returns Instant.fromEpochSeconds(0)
+        every { startedOn } returns Instant.fromEpochSeconds(0)
+    }
+
+private fun anonymousGroup(status: StudyDeploymentStatus): ParticipantGroupStatus.InDeployment =
+    participantGroupStatus(setOf(Participant(UsernameAccountIdentity("anon-${UUID.randomUUID()}"))), status)
+
 class RecruitmentServiceWrapperTest {
     private val accountService: AccountService = mockk()
     private val dataStreamService: DataStreamService = mockk()
@@ -892,6 +902,177 @@ class RecruitmentServiceWrapperTest {
                 coVerify(exactly = 1) { accountService.findByAccountIdentity(any()) }
                 coVerify(exactly = 1) { accountService.findByAccountIdentity(eai1) }
                 assertEquals(2, result.groups.single().participants.size)
+            }
+        }
+
+        @Test
+        fun `paginates matched groups and reports total`() {
+            runTest {
+                val mockStudyId = UUID.randomUUID()
+                val groups = (0 until 5).map { anonymousGroup(statusMock<StudyDeploymentStatus.Invited>()) }
+
+                coEvery {
+                    services.recruitmentService.getParticipantGroupStatusList(mockStudyId)
+                } returns groups
+                coEvery { dataStreamService.getLatestUpdatedAt(any()) } returns Instant.fromEpochSeconds(0)
+
+                val sut = createSut()
+
+                val firstPage = sut.getParticipantGroupsStatus(mockStudyId, page = 0, size = 2)
+                assertEquals(2, firstPage.groups.size)
+                assertEquals(5, firstPage.total)
+                assertEquals(groups[0].id, firstPage.groups[0].participantGroupId)
+                assertEquals(groups[1].id, firstPage.groups[1].participantGroupId)
+                // groupStatuses must be page-aligned, not the full list.
+                assertEquals(2, firstPage.groupStatuses.size)
+
+                val lastPage = sut.getParticipantGroupsStatus(mockStudyId, page = 2, size = 2)
+                assertEquals(1, lastPage.groups.size)
+                assertEquals(5, lastPage.total)
+                assertEquals(groups[4].id, lastPage.groups[0].participantGroupId)
+
+                // Only the two enriched pages (2 + 1 groups) trigger a last-upload lookup.
+                coVerify(exactly = 3) { dataStreamService.getLatestUpdatedAt(any()) }
+            }
+        }
+
+        @Test
+        fun `page offset beyond the collection returns an empty page instead of overflowing`() {
+            runTest {
+                val mockStudyId = UUID.randomUUID()
+                val groups = listOf(anonymousGroup(statusMock<StudyDeploymentStatus.Invited>()))
+
+                coEvery {
+                    services.recruitmentService.getParticipantGroupStatusList(mockStudyId)
+                } returns groups
+
+                val sut = createSut()
+
+                // page * size (1073741824 * 4) overflows Int back to 0 without the Long guard.
+                val result = sut.getParticipantGroupsStatus(mockStudyId, page = 1073741824, size = 4)
+
+                assertEquals(0, result.groups.size)
+                assertEquals(1, result.total)
+                // No page to enrich, so no last-upload lookups happen.
+                coVerify(exactly = 0) { dataStreamService.getLatestUpdatedAt(any()) }
+            }
+        }
+
+        @Test
+        fun `filtering keeps groups and statuses aligned`() {
+            runTest {
+                val mockStudyId = UUID.randomUUID()
+                val matchEai = EmailAccountIdentity("match@example.com")
+                val otherEai = EmailAccountIdentity("other@example.com")
+                val matchGroup =
+                    participantGroupStatus(setOf(Participant(matchEai)), statusMock<StudyDeploymentStatus.Invited>())
+                val otherGroup =
+                    participantGroupStatus(setOf(Participant(otherEai)), statusMock<StudyDeploymentStatus.Invited>())
+
+                coEvery {
+                    services.recruitmentService.getParticipantGroupStatusList(mockStudyId)
+                } returns listOf(matchGroup, otherGroup)
+                coEvery { accountService.findByAccountIdentity(matchEai) } returns
+                    Account(email = matchEai.emailAddress.address)
+                coEvery { dataStreamService.getLatestUpdatedAt(any()) } returns null
+
+                val sut = createSut()
+
+                val result = sut.getParticipantGroupsStatus(mockStudyId, search = "match@")
+
+                assertEquals(1, result.groups.size)
+                assertEquals(matchGroup.id, result.groups.single().participantGroupId)
+                // A filtered result must not leak the full, unfiltered status list.
+                assertEquals(1, result.groupStatuses.size)
+            }
+        }
+
+        @Test
+        fun `status filter returns only matching deployment states`() {
+            runTest {
+                val mockStudyId = UUID.randomUUID()
+                val invitedGroup = anonymousGroup(statusMock<StudyDeploymentStatus.Invited>())
+                val runningGroup = anonymousGroup(statusMock<StudyDeploymentStatus.Running>())
+
+                coEvery {
+                    services.recruitmentService.getParticipantGroupStatusList(mockStudyId)
+                } returns listOf(invitedGroup, runningGroup)
+                coEvery { dataStreamService.getLatestUpdatedAt(any()) } returns null
+
+                val sut = createSut()
+
+                val result = sut.getParticipantGroupsStatus(mockStudyId, status = "Running")
+
+                assertEquals(1, result.groups.size)
+                assertEquals(runningGroup.id, result.groups.single().participantGroupId)
+                assertEquals(1, result.groupStatuses.size)
+            }
+        }
+
+        @Test
+        fun `legacy unfiltered call returns the full status list with a null total`() {
+            runTest {
+                val mockStudyId = UUID.randomUUID()
+                val inDeployment = anonymousGroup(statusMock<StudyDeploymentStatus.Invited>())
+                val staged = mockk<ParticipantGroupStatus.Staged>()
+
+                coEvery {
+                    services.recruitmentService.getParticipantGroupStatusList(mockStudyId)
+                } returns listOf(inDeployment, staged)
+                coEvery { dataStreamService.getLatestUpdatedAt(any()) } returns null
+
+                val sut = createSut()
+
+                val result = sut.getParticipantGroupsStatus(mockStudyId)
+
+                // Only in-deployment groups are enriched, but the legacy call keeps the full status list.
+                assertEquals(1, result.groups.size)
+                assertEquals(2, result.groupStatuses.size)
+                assertNull(result.total)
+            }
+        }
+    }
+
+    @Nested
+    inner class GetParticipantGroupStatusCounts {
+        @Test
+        fun `counts deployment states and totals every group`() {
+            runTest {
+                val mockStudyId = UUID.randomUUID()
+
+                // Counting only inspects the deployment-status subtype, so mock the group directly
+                // instead of building it via fromDeploymentStatus (which needs per-subtype stubs).
+                fun deployment(status: StudyDeploymentStatus) =
+                    mockk<ParticipantGroupStatus.InDeployment>().apply {
+                        every { studyDeploymentStatus } returns status
+                    }
+                val statuses =
+                    listOf(
+                        deployment(mockk<StudyDeploymentStatus.Invited>()),
+                        deployment(mockk<StudyDeploymentStatus.Invited>()),
+                        deployment(mockk<StudyDeploymentStatus.DeployingDevices>()),
+                        deployment(mockk<StudyDeploymentStatus.Running>()),
+                        deployment(mockk<StudyDeploymentStatus.Stopped>()),
+                        mockk<ParticipantGroupStatus.Staged>(),
+                    )
+
+                coEvery {
+                    services.recruitmentService.getParticipantGroupStatusList(mockStudyId)
+                } returns statuses
+
+                val sut = createSut()
+
+                val counts = sut.getParticipantGroupStatusCounts(mockStudyId)
+
+                assertEquals(2, counts.invited)
+                assertEquals(1, counts.deployingDevices)
+                assertEquals(1, counts.running)
+                assertEquals(1, counts.stopped)
+                // total counts every participant group, including non-deployed (staged) ones.
+                assertEquals(6, counts.total)
+                // Counting must not do the expensive per-group enrichment.
+                coVerify(exactly = 0) { dataStreamService.getLatestUpdatedAt(any()) }
+                coVerify(exactly = 0) { accountService.findByAccountIdentity(any()) }
             }
         }
     }


### PR DESCRIPTION
New GET participantGroup/counts returns deployment-status totals for the overview pie. participantGroup/status now accepts page/size/search/status, enriching only the requested page; params are validated (both together, page>=0, size>=1).